### PR TITLE
Reserve logo space even before image loading

### DIFF
--- a/static/becss.css
+++ b/static/becss.css
@@ -38,6 +38,16 @@
   table-layout: fixed;
 }
 
+.navbar-header {
+  width: 100%;
+}
+
+.logo {
+  width: 100%;
+  height: 0;
+  margin-bottom: 12.82%;
+}
+
 .sidebar {
 }
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -18,7 +18,9 @@
                             <nav class="navbar navbar-default">
                                 <div class="container container-fluid">
                                     <h1 class="navbar-header">
-                                        <img class="img-responsive" src="http://echo.s-ul.eu/YGzzTGU8.png" alt=""/>
+                                        <div class="logo">
+                                            <img class="img-responsive" src="http://echo.s-ul.eu/YGzzTGU8.png" alt=""/>
+                                        </div>
                                     </h1>
                                     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                                         <ul class="nav navbar-nav">


### PR DESCRIPTION
This _should_ work! Using a [margin-bottom trick](http://afroleft.com/lazy-loading-responsive-images/).
#7 #9
